### PR TITLE
fix: 🐛 lookup message not caching correctly

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,12 @@
+## [2.2.1](https://github.com/kaisermann/svelte-i18n/compare/v2.2.0...v2.2.1) (2020-01-08)
+
+
+### Bug Fixes
+
+* 🐛 lookup message not caching correctly ([b9b6fa4](https://github.com/kaisermann/svelte-i18n/commit/b9b6fa41ffd99b89fc117c44a5bc636335c63632))
+
+
+
 # [2.2.0](https://github.com/kaisermann/svelte-i18n/compare/v2.1.1...v2.2.0) (2020-01-07)
 
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "svelte-i18n",
-  "version": "2.1.0",
+  "version": "2.2.1",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -7035,15 +7035,15 @@
       }
     },
     "rollup-plugin-terser": {
-      "version": "5.1.2",
-      "resolved": "https://registry.npmjs.org/rollup-plugin-terser/-/rollup-plugin-terser-5.1.2.tgz",
-      "integrity": "sha512-sWKBCOS+vUkRtHtEiJPAf+WnBqk/C402fBD9AVHxSIXMqjsY7MnYWKYEUqGixtr0c8+1DjzUEPlNgOYQPVrS1g==",
+      "version": "5.1.3",
+      "resolved": "https://registry.npmjs.org/rollup-plugin-terser/-/rollup-plugin-terser-5.1.3.tgz",
+      "integrity": "sha512-FuFuXE5QUJ7snyxHLPp/0LFXJhdomKlIx/aK7Tg88Yubsx/UU/lmInoJafXJ4jwVVNcORJ1wRUC5T9cy5yk0wA==",
       "dev": true,
       "requires": {
         "@babel/code-frame": "^7.0.0",
         "jest-worker": "^24.6.0",
         "rollup-pluginutils": "^2.8.1",
-        "serialize-javascript": "^1.7.0",
+        "serialize-javascript": "^2.1.2",
         "terser": "^4.1.0"
       }
     },
@@ -7193,9 +7193,9 @@
       "dev": true
     },
     "serialize-javascript": {
-      "version": "1.9.1",
-      "resolved": "https://registry.npmjs.org/serialize-javascript/-/serialize-javascript-1.9.1.tgz",
-      "integrity": "sha512-0Vb/54WJ6k5v8sSWN09S0ora+Hnr+cX40r9F170nT+mSkaxltoE/7R3OrIdBSUv1OoiobH1QoWQbCnAO+e8J1A==",
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/serialize-javascript/-/serialize-javascript-2.1.2.tgz",
+      "integrity": "sha512-rs9OggEUF0V4jUSecXazOYsLfu7OGK2qIn3c7IPBiffz32XniEp/TX9Xmc9LQfK2nQ2QKHvZ2oygKUGU0lG4jQ==",
       "dev": true
     },
     "set-blocking": {
@@ -7804,9 +7804,9 @@
       }
     },
     "terser": {
-      "version": "4.4.0",
-      "resolved": "https://registry.npmjs.org/terser/-/terser-4.4.0.tgz",
-      "integrity": "sha512-oDG16n2WKm27JO8h4y/w3iqBGAOSCtq7k8dRmrn4Wf9NouL0b2WpMHGChFGZq4nFAQy1FsNJrVQHfurXOSTmOA==",
+      "version": "4.6.2",
+      "resolved": "https://registry.npmjs.org/terser/-/terser-4.6.2.tgz",
+      "integrity": "sha512-6FUjJdY2i3WZAtYBtnV06OOcOfzl+4hSKYE9wgac8rkLRBToPDDrBB2AcHwQD/OKDxbnvhVy2YgOPWO2SsKWqg==",
       "dev": true,
       "requires": {
         "commander": "^2.20.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "svelte-i18n",
-  "version": "2.2.0",
+  "version": "2.2.1",
   "main": "dist/i18n.js",
   "module": "dist/i18n.mjs",
   "bin": {
@@ -69,7 +69,7 @@
     "rollup": "^1.26.5",
     "rollup-plugin-auto-external": "^2.0.0",
     "rollup-plugin-commonjs": "^10.1.0",
-    "rollup-plugin-terser": "^5.1.2",
+    "rollup-plugin-terser": "^5.1.3",
     "rollup-plugin-typescript2": "^0.25.2",
     "sass": "^1.23.6",
     "svelte": "^3.14.1",

--- a/src/client/includes/lookup.ts
+++ b/src/client/includes/lookup.ts
@@ -10,14 +10,24 @@ const addToCache = (path: string, locale: string, message: string) => {
   return message
 }
 
-export const lookupMessage = (path: string, locale: string): string => {
+const searchForMessage = (path: string, locale: string): string => {
   if (locale == null) return null
-  if (locale in lookupCache && path in lookupCache[locale]) {
-    return lookupCache[locale][path]
-  }
 
   const message = getMessageFromDictionary(locale, path)
   if (message) return message
 
-  return addToCache(path, locale, lookupMessage(path, getFallbackOf(locale)))
+  return searchForMessage(path, getFallbackOf(locale))
+}
+
+export const lookup = (path: string, locale: string) => {
+  if (locale in lookupCache && path in lookupCache[locale]) {
+    return lookupCache[locale][path]
+  }
+
+  const message = searchForMessage(path, locale)
+  if (message) {
+    return addToCache(path, locale, message)
+  }
+
+  return null
 }

--- a/src/client/stores/format.ts
+++ b/src/client/stores/format.ts
@@ -1,7 +1,7 @@
 import { derived } from 'svelte/store'
 
 import { Formatter, MessageObject } from '../types'
-import { lookupMessage } from '../includes/lookup'
+import { lookup } from '../includes/lookup'
 import { hasLocaleQueue } from '../includes/loaderQueue'
 import { capital, upper, lower, title } from '../includes/utils'
 import {
@@ -29,7 +29,7 @@ const formatMessage: Formatter = (id, options = {}) => {
     )
   }
 
-  const message = lookupMessage(id, locale)
+  const message = lookup(id, locale)
 
   if (!message) {
     if (getOptions().warnOnMissingMessages) {

--- a/src/client/stores/locale.ts
+++ b/src/client/stores/locale.ts
@@ -28,6 +28,7 @@ export function getFallbackOf(locale: string) {
   if (fallbackLocale && !isRelatedLocale(locale, fallbackLocale)) {
     return fallbackLocale
   }
+
   return null
 }
 

--- a/test/client/includes/lookup.test.ts
+++ b/test/client/includes/lookup.test.ts
@@ -1,4 +1,4 @@
-import { lookupMessage, lookupCache } from '../../../src/client/includes/lookup'
+import { lookup, lookupCache } from '../../../src/client/includes/lookup'
 import { $dictionary, addMessages } from '../../../src/client/stores/dictionary'
 
 beforeEach(() => {
@@ -6,43 +6,46 @@ beforeEach(() => {
 })
 
 test('returns null if no locale was passed', () => {
-  expect(lookupMessage('message.id', undefined)).toBe(null)
-  expect(lookupMessage('message.id', null)).toBe(null)
+  expect(lookup('message.id', undefined)).toBe(null)
+  expect(lookup('message.id', null)).toBe(null)
 })
 
 test('gets a shallow message of a locale dictionary', () => {
   addMessages('en', { field: 'name' })
-  expect(lookupMessage('field', 'en')).toBe('name')
+
+  expect(lookup('field', 'en')).toBe('name')
 })
 
 test('gets a deep message of a locale dictionary', () => {
   addMessages('en', { deep: { field: 'lastname' } })
-  expect(lookupMessage('deep.field', 'en')).toBe('lastname')
+  expect(lookup('deep.field', 'en')).toBe('lastname')
 })
 
 test('gets a message from the fallback dictionary', () => {
   addMessages('en', { field: 'name' })
-  expect(lookupMessage('field', 'en-US')).toBe('name')
+
+  expect(lookup('field', 'en-US')).toBe('name')
 })
 
 test('caches found messages by locale', () => {
   addMessages('en', { field: 'name' })
   addMessages('pt', { field: 'nome' })
-  lookupMessage('field', 'en-US')
-  lookupMessage('field', 'pt-BR')
+  lookup('field', 'en-US')
+  lookup('field', 'pt')
+
   expect(lookupCache).toMatchObject({
     'en-US': { field: 'name' },
-    'pt-BR': { field: 'nome' },
+    pt: { field: 'nome' },
   })
 })
 
 test("doesn't cache falsy messages", () => {
   addMessages('en', { field: 'name' })
   addMessages('pt', { field: 'nome' })
-  lookupMessage('field_2', 'en-US')
-  lookupMessage('field_2', 'pt-BR')
+  lookup('field_2', 'en-US')
+  lookup('field_2', 'pt')
   expect(lookupCache).not.toMatchObject({
     'en-US': { field_2: 'name' },
-    'pt-BR': { field_2: 'nome' },
+    pt: { field_2: 'nome' },
   })
 })

--- a/test/client/stores/locale.test.ts
+++ b/test/client/stores/locale.test.ts
@@ -1,6 +1,6 @@
 import { get } from 'svelte/store'
 
-import { lookupMessage } from '../../../src/client/includes/lookup'
+import { lookup } from '../../../src/client/includes/lookup'
 import {
   isFallbackLocaleOf,
   getFallbackOf,
@@ -132,5 +132,5 @@ test('should flush the queue of the locale when changing the store value', async
   await $locale.set('en')
 
   expect(hasLocaleQueue('en')).toBe(false)
-  expect(lookupMessage('foo', 'en')).toBe('Foo')
+  expect(lookup('foo', 'en')).toBe('Foo')
 })


### PR DESCRIPTION
It was only caching lookups of fallback locales. If a message was found
in the passed locale, it wouldn't be cached.

### Tests

- [x] Run the tests tests with `npm test` or `yarn test`
