### PR TITLE
Fix memoizing of formatters when no locale is given.

### DIFF
--- a/src/runtime/includes/formatters.ts
+++ b/src/runtime/includes/formatters.ts
@@ -18,11 +18,10 @@ const getIntlFormatterOptions = (
   throw new Error(`[svelte-i18n] Unknown "${name}" ${type} format.`)
 }
 
-export const getNumberFormatter: MemoizedIntlFormatter<
+const createNumberFormatter: MemoizedIntlFormatter<
   Intl.NumberFormat,
   Intl.NumberFormatOptions
-> = monadicMemoize(({ locale, format, ...options } = {}) => {
-  locale = locale || getCurrentLocale()
+> = monadicMemoize(({ locale, format, ...options }) => {
   if (locale == null) {
     throw new Error('[svelte-i18n] A "locale" must be set to format numbers')
   }
@@ -33,12 +32,12 @@ export const getNumberFormatter: MemoizedIntlFormatter<
 
   return new Intl.NumberFormat(locale, options)
 })
+export const getNumberFormatter = ({ locale = getCurrentLocale(), ...args } = {}) => createNumberFormatter({ locale, ...args })
 
-export const getDateFormatter: MemoizedIntlFormatter<
+const createDateFormatter: MemoizedIntlFormatter<
   Intl.DateTimeFormat,
   Intl.DateTimeFormatOptions
-> = monadicMemoize(({ locale, format, ...options } = {}) => {
-  locale = locale || getCurrentLocale()
+> = monadicMemoize(({ locale, format, ...options }) => {
   if (locale == null) {
     throw new Error('[svelte-i18n] A "locale" must be set to format dates')
   }
@@ -50,12 +49,12 @@ export const getDateFormatter: MemoizedIntlFormatter<
 
   return new Intl.DateTimeFormat(locale, options)
 })
+export const getDateFormatter = ({ locale = getCurrentLocale(), ...args } = {}) => createDateFormatter({ locale, ...args })
 
-export const getTimeFormatter: MemoizedIntlFormatter<
+const createTimeFormatter: MemoizedIntlFormatter<
   Intl.DateTimeFormat,
   Intl.DateTimeFormatOptions
-> = monadicMemoize(({ locale, format, ...options } = {}) => {
-  locale = locale || getCurrentLocale()
+> = monadicMemoize(({ locale, format, ...options }) => {
   if (locale == null) {
     throw new Error(
       '[svelte-i18n] A "locale" must be set to format time values'
@@ -69,6 +68,7 @@ export const getTimeFormatter: MemoizedIntlFormatter<
 
   return new Intl.DateTimeFormat(locale, options)
 })
+export const getTimeFormatter = ({ locale = getCurrentLocale(), ...args } = {}) => createTimeFormatter({ locale, ...args })
 
 export const getMessageFormatter = monadicMemoize(
   (message: string, locale: string = getCurrentLocale()) =>

--- a/test/runtime/includes/formatters.test.ts
+++ b/test/runtime/includes/formatters.test.ts
@@ -3,7 +3,8 @@ import {
   getDateFormatter,
   getTimeFormatter,
   getMessageFormatter,
-  init
+  init,
+  locale
 } from '../../../src/runtime'
 
 beforeEach(() => {
@@ -19,7 +20,7 @@ describe('number formatter', () => {
     )
   })
 
-  test('formats a date according to the current locale', () => {
+  test('formats a number according to the current locale', () => {
     init({ fallbackLocale: 'en' })
     expect(getNumberFormatter().format(number)).toBe('123,123')
   })
@@ -48,6 +49,14 @@ describe('number formatter', () => {
     expect(
       getNumberFormatter({ style: 'currency', currency: 'BRL' }).format(number)
     ).toBe('R$123,123.00')
+  })
+
+  test('formats a number according to the currently set locale', () => {
+    locale.set('en')
+    expect(getNumberFormatter().format(number)).toBe('123,123')
+
+    locale.set('nl')
+    expect(getNumberFormatter().format(number)).toBe('123.123')
   })
 })
 
@@ -97,6 +106,14 @@ describe('date formatter', () => {
     expect(
       getDateFormatter({ year: 'numeric', era: 'short' }).format(date)
     ).toBe('2019 AD')
+  })
+
+  test('formats a date according to the currently set locale', () => {
+    locale.set('en')
+    expect(getDateFormatter().format(date)).toBe('2/1/19')
+
+    locale.set('nl')
+    expect(getDateFormatter().format(date)).toBe('1-2-19')
   })
 })
 
@@ -150,6 +167,14 @@ describe('time formatter', () => {
         second: '2-digit',
       }).format(time)
     ).toBe('08:37:32 PM')
+  })
+
+  test('formats time according to the currently set locale', () => {
+    locale.set('en')
+    expect(getTimeFormatter().format(time)).toBe('8:37 PM')
+
+    locale.set('nl')
+    expect(getTimeFormatter().format(time)).toBe('20:37')
   })
 })
 


### PR DESCRIPTION
Currently the get format functions are not pure so they can't be memoized.
I noticed this during SSR while formatting dates and amounts without passing a locale, like so:
```javascript
{$_.date(new Date(), { format: 'full' }).toUpperCase()}
```
and
```javascript
{$_.number(10.99, { format: 'EUR' })}
```
This caches the internally created formatter for all further requests.
On other requests, in a different language, `locale.set('xx-YY')` the incorrect language would be used for formatting.