### PR TITLE
WIP: Return array/object instead string when possible

### DIFF
--- a/src/runtime/includes/flatObj.ts
+++ b/src/runtime/includes/flatObj.ts
@@ -3,14 +3,7 @@ export const flatObj = (obj: Record<string, any>, prefix = '') => {
   const flatted: Record<string, string> = {};
 
   for (const key in obj) {
-    const flatKey = prefix + key;
-
-    // we want plain objects and arrays
-    if (typeof obj[key] === 'object') {
-      Object.assign(flatted, flatObj(obj[key], `${flatKey}.`));
-    } else {
-      flatted[flatKey] = obj[key];
-    }
+    flatted[prefix + key] = obj[key];
   }
 
   return flatted;

--- a/src/runtime/includes/formatters.ts
+++ b/src/runtime/includes/formatters.ts
@@ -90,6 +90,6 @@ export const getTimeFormatter: MemoizedDateTimeFormatterFactory = ({
 } = {}) => createTimeFormatter({ locale, ...args });
 
 export const getMessageFormatter = monadicMemoize(
-  (message: string, locale: string = getCurrentLocale()) =>
+  (message: string | any[], locale: string = getCurrentLocale()) =>
     new IntlMessageFormat(message, locale, getOptions().formats),
 );

--- a/src/runtime/includes/lookup.ts
+++ b/src/runtime/includes/lookup.ts
@@ -1,9 +1,9 @@
 import { getMessageFromDictionary } from '../stores/dictionary';
 import { getFallbackOf } from '../stores/locale';
 
-export const lookupCache: Record<string, Record<string, string>> = {};
+export const lookupCache: Record<string, Record<string, string | any[]>> = {};
 
-const addToCache = (path: string, locale: string, message: string) => {
+const addToCache = (path: string, locale: string, message: string | any[]) => {
   if (!message) return message;
   if (!(locale in lookupCache)) lookupCache[locale] = {};
   if (!(path in lookupCache[locale])) lookupCache[locale][path] = message;
@@ -11,7 +11,7 @@ const addToCache = (path: string, locale: string, message: string) => {
   return message;
 };
 
-const searchForMessage = (path: string, locale: string): string => {
+const searchForMessage = (path: string, locale: string): string | any[] => {
   if (locale == null) return null;
 
   const message = getMessageFromDictionary(locale, path);

--- a/src/runtime/includes/memoize.ts
+++ b/src/runtime/includes/memoize.ts
@@ -3,7 +3,7 @@ type MemoizedFunction = <F extends Function>(fn: F) => F;
 
 const monadicMemoize: MemoizedFunction = (fn) => {
   const cache = Object.create(null);
-  const memoizedFn: any = (arg: unknown) => {
+  const memoizedFn: any = (arg: any[]) => {
     const cacheKey = JSON.stringify(arg);
 
     if (cacheKey in cache) {

--- a/src/runtime/stores/dictionary.ts
+++ b/src/runtime/stores/dictionary.ts
@@ -23,6 +23,22 @@ export function getMessageFromDictionary(locale: string, id: string) {
   if (hasLocaleDictionary(locale)) {
     const localeDictionary = getLocaleDictionary(locale);
 
+    if (/^(\w+\.)+\w+$/.test(id)) {
+      const keys = id.split('.');
+
+      const value: Map<string, any> = new Map<string, any>();
+
+      for (const [index, key] of keys.entries()) {
+        if (index === 0) {
+          value.set('message', localeDictionary[key]);
+        } else {
+          value.set('message', value.get('message')[key]);
+        }
+      }
+
+      return value.get('message');
+    }
+
     if (id in localeDictionary) {
       return localeDictionary[id];
     }
@@ -41,7 +57,31 @@ export function addMessages(locale: string, ...partials: DeepDictionary[]) {
   const flattedPartials = partials.map((partial) => flatObj(partial));
 
   $dictionary.update((d) => {
+    const test = d[locale] !== undefined ? d[locale] : {};
+
+    console.log(
+      'AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA',
+      test,
+    );
+    console.log(
+      'AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA',
+      d[locale] || {},
+    );
+
+    console.log(
+      'RRRRRRRRRRRRRRRRRRRRRRRRRRRRRRRRRRRRRRRRRRRRRRRRRRRRRRRRRRRRRRRRRRRR',
+      { ...test[locale], ...flattedPartials },
+    );
+    console.log(
+      'PPPPPPPPPPPPPPPPPPPPPPPPPPPPPPPPPPPPPPPPPPPPPPPPPPPPPPPPPPPPPPPPPPPPPPPPPPPPP',
+      Object.assign(d[locale] || {}, ...flattedPartials),
+    );
+
     d[locale] = Object.assign(d[locale] || {}, ...flattedPartials);
+    console.log(
+      'UPPPPPPPPPPPPPPPPPPPPPPPPPPPPPPPPPPPPPPPPPPPPPPPPPPPPPPPPPPPPPPPPPPPPPPPPPPPPPPPPPPPPP',
+      d,
+    );
 
     return d;
   });

--- a/src/runtime/stores/formatters.ts
+++ b/src/runtime/stores/formatters.ts
@@ -58,6 +58,14 @@ const formatMessage: MessageFormatter = (id, options = {}) => {
 
   if (!values) return message;
 
+  if (typeof message === 'object') {
+    for (const [i, m] of message.entries()) {
+      message[i] = getMessageFormatter(m, locale).format(values);
+    }
+
+    return message;
+  }
+
   return getMessageFormatter(message, locale).format(values);
 };
 

--- a/src/runtime/types/index.ts
+++ b/src/runtime/types/index.ts
@@ -3,7 +3,7 @@ import { Formats } from 'intl-messageformat';
 export interface DeepDictionary {
   [key: string]: DeepDictionary | string | string[];
 }
-export type LocaleDictionary = Record<string, string>;
+export type LocaleDictionary = Record<string, any[]>;
 export type Dictionary = Record<string, LocaleDictionary>;
 
 export interface MessageObject {
@@ -17,7 +17,7 @@ export interface MessageObject {
 export type MessageFormatter = (
   id: string | MessageObject,
   options?: MessageObject,
-) => string;
+) => string | any[];
 
 export type TimeFormatter = (
   d: Date | number,

--- a/test/fixtures/en.json
+++ b/test/fixtures/en.json
@@ -1,9 +1,12 @@
 {
   "form": {
     "field_1_name": "Name",
-    "field_2_name": "Lastname"
+    "field_2_name": "Lastname",
+    "field_3_name": ["yes", "no"]
   },
   "photos": "You have {n, plural, =0 {no photos.} =1 {one photo.} other {# photos.}}",
   "title": "Page title",
-  "sneakers": "sneakers"
+  "sneakers": "sneakers",
+  "food": ["Pizza", "Burger", "Sushi"],
+  "welcome": ["Hello {name}!", "How are you {name}?"]
 }

--- a/test/fixtures/pt.json
+++ b/test/fixtures/pt.json
@@ -1,9 +1,12 @@
 {
   "form": {
     "field_1_name": "Nome",
-    "field_2_name": "Sobrenome"
+    "field_2_name": "Sobrenome",
+    "field_3_name": ["sim", "não"]
   },
   "photos": "Você {n, plural, =0 {não tem fotos.} =1 {tem uma foto.} other {tem # fotos.}}",
   "title": "Título da página",
-  "sneakers": "tênis"
+  "sneakers": "tênis",
+  "food": ["Pizza", "Hambúrguer", "Sushi"],
+  "welcome": ["Ola {name} !", "Como você está {name} ?"]
 }

--- a/test/runtime/includes/utils.test.ts
+++ b/test/runtime/includes/utils.test.ts
@@ -54,8 +54,16 @@ describe('deep object handling', () => {
       e: { f: 'bar' },
     }
     expect(flatObj(obj)).toMatchObject({
-      'a.b.c.d': 'foo',
-      'e.f': 'bar',
+      a: {
+        b: {
+          c: {
+            d: 'foo',
+          },
+        },
+      },
+      e: {
+        f: 'bar',
+      },
     })
   })
 
@@ -65,10 +73,16 @@ describe('deep object handling', () => {
       e: { f: ['foo', 'bar'] },
     }
     expect(flatObj(obj)).toMatchObject({
-      'a.b.c.d.0': 'foo',
-      'a.b.c.d.1': 'bar',
-      'e.f.0': 'foo',
-      'e.f.1': 'bar',
+      a: {
+        b: {
+          c: {
+            d: ['foo', 'bar'],
+          },
+        },
+      },
+      e: {
+        f: ['foo', 'bar'],
+      },
     })
   })
 })

--- a/test/runtime/stores/dictionary.test.ts
+++ b/test/runtime/stores/dictionary.test.ts
@@ -40,14 +40,18 @@ test('merges the existing dictionaries with new ones', () => {
     en: {
       field_1: 'name',
       field_2: 'lastname',
-      'deep.prop1': 'foo',
-      'deep.prop2': 'foo',
+      deep: {
+        prop1: 'foo',
+        prop2: 'foo',
+      },
     },
     pt: {
       field_1: 'nome',
       field_2: 'sobrenome',
-      'deep.prop1': 'foo',
-      'deep.prop2': 'foo',
+      deep: {
+        prop1: 'foo',
+        prop2: 'foo',
+      },
     },
   })
 })
@@ -70,7 +74,7 @@ test('gets the closest available locale', () => {
 
 test("returns null if there's no closest locale available", () => {
   addMessages('pt', { field_1: 'name' })
-  expect(getClosestAvailableLocale('it-IT')).toBe(null)
+  expect(getClosestAvailableLocale('it-it')).toBe(null)
 })
 
 test('lists all locales in the dictionary', () => {
@@ -89,7 +93,7 @@ describe('getting messages', () => {
   test('gets a message from a deep object in the dictionary', () => {
     addMessages('en', { messages: { message_1: 'Some message' } })
     expect(getMessageFromDictionary('en', 'messages.message_1')).toBe(
-      'Some message'
+      'Some message',
     )
   })
 

--- a/test/runtime/stores/formatters.test.ts
+++ b/test/runtime/stores/formatters.test.ts
@@ -61,6 +61,38 @@ test('accepts a message id as first argument', () => {
   expect(formatMessage('form.field_1_name')).toBe('Name')
 })
 
+test('accepts a message id as first argument and return an array of an object', () => {
+  expect(formatMessage('form.field_3_name')).toEqual(
+    expect.arrayContaining(['yes', 'no']),
+  )
+})
+
+test('accepts a message id as first argument and return a given value of an array inside an object', () => {
+  expect(formatMessage('form.field_3_name.1')).toBe('no')
+})
+
+test('accepts a message id as first argument', () => {
+  expect(formatMessage('food')).toEqual(
+    expect.arrayContaining(['Pizza', 'Burger', 'Sushi']),
+  )
+})
+
+test('accepts a message id as first argument', () => {
+  expect(formatMessage('food.0')).toBe('Pizza')
+})
+
+test('accepts a message id as first argument', () => {
+  expect(formatMessage({ id: 'welcome', values: { name: 'Jérôme' } })).toEqual(
+    expect.arrayContaining(['Hello Jérôme!', 'How are you Jérôme?']),
+  )
+})
+
+test('accepts a message id as first argument', () => {
+  expect(formatMessage({ id: 'welcome.0', values: { name: 'Jérôme' } })).toBe(
+    'Hello Jérôme!',
+  )
+})
+
 test('accepts a message id as first argument and formatting options as second', () => {
   expect(formatMessage('form.field_1_name', { locale: 'pt' })).toBe('Nome')
 })


### PR DESCRIPTION
Fixes #83 

### Before submitting the PR, please make sure you do the following

- [x] It's really useful if your PR relates to an outstanding issue, so please reference it in your PR, or create an explanatory one for discussion. In many cases features are absent for a reason.
- [x] This message body should clearly illustrate what problems it solves. If there are related issues, remember to reference them.
- [x] Ideally, include a test that fails without this PR but passes with it. PRs will only be merged once they pass CI. (Remember to `npm run lint`!)

### Tests

- [ ] Run the tests tests with `npm test` or `yarn test`

Returns object or array instead flatted object. Objects are not flatted anymore, plain JavaScript object is returned.

Strings `{variable}` are still working, even in nested objects.

- [ ] Write some docs

