### PR TITLE
Expose intl-messageformat option `ignoreTag`

### DIFF
--- a/src/runtime/configs.ts
+++ b/src/runtime/configs.ts
@@ -44,6 +44,7 @@ export const defaultOptions: ConfigureOptions = {
   loadingDelay: 200,
   formats: defaultFormats,
   warnOnMissingMessages: true,
+  ignoreTag: true,
 };
 
 const options: ConfigureOptions = defaultOptions;

--- a/src/runtime/includes/formatters.ts
+++ b/src/runtime/includes/formatters.ts
@@ -91,5 +91,7 @@ export const getTimeFormatter: MemoizedDateTimeFormatterFactory = ({
 
 export const getMessageFormatter = monadicMemoize(
   (message: string, locale: string = getCurrentLocale()) =>
-    new IntlMessageFormat(message, locale, getOptions().formats),
+    new IntlMessageFormat(message, locale, getOptions().formats, {
+      ignoreTag: getOptions().ignoreTag,
+    }),
 );

--- a/src/runtime/types/index.ts
+++ b/src/runtime/types/index.ts
@@ -70,4 +70,5 @@ export interface ConfigureOptions {
   initialLocale?: string;
   loadingDelay?: number;
   warnOnMissingMessages?: boolean;
+  ignoreTag?: boolean;
 }

--- a/test/runtime/includes/formatters.test.ts
+++ b/test/runtime/includes/formatters.test.ts
@@ -195,4 +195,16 @@ describe('message formatter', () => {
       }),
     ).toBe('Number: 2M');
   });
+
+  it('formats an html message with interpolated values', () => {
+    expect(
+      getMessageFormatter(
+        'Page: <soan class="text-bold">{current,number}/{max,number}</soan>',
+        'en',
+      ).format({
+        current: 2,
+        max: 10,
+      }),
+    ).toBe('Page: <soan class="text-bold">2/10</soan>');
+  });
 });


### PR DESCRIPTION
With the latest release and move to the latest intl-messageformat messages that include variables and HTML tags have started to throw errors.

This PR exposes the new option `ignoreTag` and defaults it to true for backwards compatibility.

See issue #120 

### Before submitting the PR, please make sure you do the following

- [x] It's really useful if your PR relates to an outstanding issue, so please reference it in your PR, or create an explanatory one for discussion. In many cases features are absent for a reason.
- [x] This message body should clearly illustrate what problems it solves. If there are related issues, remember to reference them.
- [x] Ideally, include a test that fails without this PR but passes with it. PRs will only be merged once they pass CI. (Remember to `npm run lint`!)

### Tests

- [x] Run the tests tests with `npm test` or `yarn test`
