### PR TITLE
Fix a broken link in the Methods docs page

### DIFF
--- a/docs/Methods.md
+++ b/docs/Methods.md
@@ -284,7 +284,7 @@ getNumberFormatter(
 ): Intl.NumberFormat
 ```
 
-Each of these methods return their respective [`Intl.xxxxFormatter`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects#Internationalization) variant. Click [here](/docs/formatting.md#accessing-formatters-directly) for an example of usage.
+Each of these methods return their respective [`Intl.xxxxFormatter`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects#Internationalization) variant. Click [here](/docs/Formatting.md#accessing-formatters-directly) for an example of usage.
 
 #### `getMessageFormatter`
 


### PR DESCRIPTION
In the [Methods page of the docs](https://github.com/kaisermann/svelte-i18n/blob/main/docs/Methods.md#low-level-api), you have a link at the very bottom, just before `getMessageFormatter`:

> ... Click [here](https://github.com/kaisermann/svelte-i18n/blob/main/docs/formatting.md#accessing-formatters-directly) for an example of usage.

That link points to `formatting.md`, while the file is called `Formatting.md`. This results in a 404. This PR is to address that.