### PR TITLE
fix crash if message has syntax error

### DIFF
--- a/src/runtime/stores/formatters.ts
+++ b/src/runtime/stores/formatters.ts
@@ -67,7 +67,18 @@ const formatMessage: MessageFormatter = (id, options = {}) => {
     return message;
   }
 
-  return getMessageFormatter(message, locale).format(values) as string;
+  let result = message;
+
+  try {
+    result = getMessageFormatter(message, locale).format(values) as string;
+  } catch (e) {
+    console.warn(
+      `[svelte-i18n] Message with "${id}" has syntax error:`,
+      e.message,
+    );
+  }
+
+  return result;
 };
 
 const formatTime: TimeFormatter = (t, options) => {

--- a/test/runtime/includes/formatters.test.ts
+++ b/test/runtime/includes/formatters.test.ts
@@ -7,6 +7,8 @@ import {
   locale,
 } from '../../../src/runtime';
 
+const formatsJson = require('../../fixtures/formats.json');
+
 beforeEach(() => {
   init({ fallbackLocale: undefined });
 });
@@ -35,7 +37,7 @@ describe('number formatter', () => {
   it('formats a number with a custom format', () => {
     init({
       fallbackLocale: 'en',
-      formats: require('../../fixtures/formats.json'),
+      formats: formatsJson,
     });
 
     expect(getNumberFormatter({ format: 'brl' }).format(number)).toBe(
@@ -81,7 +83,7 @@ describe('date formatter', () => {
   it('throws if passed a non-existing format', () => {
     init({
       fallbackLocale: 'en',
-      formats: require('../../fixtures/formats.json'),
+      formats: formatsJson,
     });
 
     expect(() =>
@@ -92,7 +94,7 @@ describe('date formatter', () => {
   it('formats a date with a custom format', () => {
     init({
       fallbackLocale: 'en',
-      formats: require('../../fixtures/formats.json'),
+      formats: formatsJson,
     });
 
     expect(getDateFormatter({ format: 'customDate' }).format(date)).toBe(
@@ -138,7 +140,7 @@ describe('time formatter', () => {
   it('formats a time with a custom format', () => {
     init({
       fallbackLocale: 'en',
-      formats: require('../../fixtures/formats.json'),
+      formats: formatsJson,
     });
 
     expect(getTimeFormatter({ format: 'customTime' }).format(time)).toBe(
@@ -149,7 +151,7 @@ describe('time formatter', () => {
   it('throws if passed a non-existing format', () => {
     init({
       fallbackLocale: 'en',
-      formats: require('../../fixtures/formats.json'),
+      formats: formatsJson,
     });
 
     expect(() =>
@@ -189,6 +191,7 @@ describe('message formatter', () => {
   });
 
   it('formats number with custom formats', () => {
+    locale.set('en');
     expect(
       getMessageFormatter('Number: {n, number, compactShort}', 'en').format({
         n: 2000000,


### PR DESCRIPTION
### Before submitting the PR, please make sure you do the following

- [ ] It's really useful if your PR relates to an outstanding issue, so please reference it in your PR, or create an explanatory one for discussion. In many cases features are absent for a reason.
- [x] This message body should clearly illustrate what problems it solves. If there are related issues, remember to reference them.
- [ ] Ideally, include a test that fails without this PR but passes with it. PRs will only be merged once they pass CI. (Remember to `npm run lint`!)

### Tests

- [ ] Run the tests tests with `npm test` or `yarn test`


Message example:

```Hello {{name}}!```

Then app crashed with this error:

```Uncaught (in promise) SyntaxError: Expected argNameOrNumber but "{" found.```