### PR TITLE
Fix cannot update changed messages in the dictionary

### DIFF
--- a/src/runtime/stores/dictionary.ts
+++ b/src/runtime/stores/dictionary.ts
@@ -4,6 +4,7 @@ import deepmerge from 'deepmerge';
 import type { LocaleDictionary, LocalesDictionary } from '../types/index';
 import { getFallbackOf } from './locale';
 import { delve } from '../../shared/delve';
+import { lookupCache } from '../includes/lookup';
 
 let dictionary: LocalesDictionary;
 const $dictionary = writable<LocalesDictionary>({});
@@ -39,6 +40,8 @@ export function getClosestAvailableLocale(locale: string): string | null {
 }
 
 export function addMessages(locale: string, ...partials: LocaleDictionary[]) {
+  delete lookupCache[locale];
+
   $dictionary.update((d) => {
     d[locale] = deepmerge.all<LocaleDictionary>([d[locale] || {}, ...partials]);
 

--- a/test/runtime/includes/lookup.test.ts
+++ b/test/runtime/includes/lookup.test.ts
@@ -83,3 +83,11 @@ test("doesn't cache falsy messages", () => {
     pt: { field_2: 'nome' },
   });
 });
+
+test('updates message of a locale dictionary', () => {
+  addMessages('en', { field: 'name' });
+  expect(lookup('field', 'en')).toBe('name');
+
+  addMessages('en', { field: 'name2' });
+  expect(lookup('field', 'en')).toBe('name2');
+});

--- a/test/runtime/includes/lookup.test.ts
+++ b/test/runtime/includes/lookup.test.ts
@@ -84,7 +84,7 @@ test("doesn't cache falsy messages", () => {
   });
 });
 
-test('updates message of a locale dictionary', () => {
+test('clears a locale lookup cache when new messages are added', () => {
   addMessages('en', { field: 'name' });
   expect(lookup('field', 'en')).toBe('name');
 


### PR DESCRIPTION
Hello (:

This is a fix for #107. It clears the `lookupCache` for a `locale` when `addMessages` is called.

### Before submitting the PR, please make sure you do the following

- [x] It's really useful if your PR relates to an outstanding issue, so please reference it in your PR, or create an explanatory one for discussion. In many cases features are absent for a reason.
- [x] This message body should clearly illustrate what problems it solves. If there are related issues, remember to reference them.
- [x] Ideally, include a test that fails without this PR but passes with it. PRs will only be merged once they pass CI. (Remember to `npm run lint`!)

### Tests

- [x] Run the tests tests with `npm test` or `yarn test`
