### PR TITLE
fix: enable typescript strictNullChecks

### DIFF
--- a/src/cli/extract.ts
+++ b/src/cli/extract.ts
@@ -1,3 +1,4 @@
+/* eslint-disable @typescript-eslint/no-non-null-assertion */
 import type {
   Node,
   ObjectExpression,
@@ -145,7 +146,7 @@ export function collectMessages(markup: string): Message[] {
     ...definitions.map((definition) => getObjFromExpression(definition)),
     ...calls.map((call) => {
       const [pathNode, options] = call.arguments;
-      let messageObj: Partial<Message>;
+      let messageObj: Message;
 
       if (pathNode.type === 'ObjectExpression') {
         // _({ ...opts })
@@ -168,7 +169,7 @@ export function collectMessages(markup: string): Message[] {
 
       return messageObj;
     }),
-  ].filter((Boolean as unknown) as (x: Message | null) => x is Message);
+  ].filter(Boolean) as Message[];
 }
 
 export function extractMessages(

--- a/src/cli/extract.ts
+++ b/src/cli/extract.ts
@@ -23,7 +23,7 @@ const FORMAT_METHOD_NAMES = new Set(['format', '_', 't']);
 function isFormatCall(node: Node, imports: Set<string>) {
   if (node.type !== 'CallExpression') return false;
 
-  let identifier: Identifier;
+  let identifier: Identifier | undefined;
 
   if (node.callee.type === 'Identifier') {
     identifier = node.callee;
@@ -125,7 +125,9 @@ export function collectMessageDefinitions(ast: Ast) {
     definitionDict.properties.map((propNode) => {
       if (propNode.type !== 'Property') {
         throw new Error(
-          `Found invalid '${propNode.type}' at L${propNode.loc.start.line}:${propNode.loc.start.column}`,
+          `Found invalid '${propNode.type}' at L${propNode.loc!.start.line}:${
+            propNode.loc!.start.column
+          }`,
         );
       }
 
@@ -143,7 +145,7 @@ export function collectMessages(markup: string): Message[] {
     ...definitions.map((definition) => getObjFromExpression(definition)),
     ...calls.map((call) => {
       const [pathNode, options] = call.arguments;
-      let messageObj;
+      let messageObj: Partial<Message>;
 
       if (pathNode.type === 'ObjectExpression') {
         // _({ ...opts })
@@ -166,7 +168,7 @@ export function collectMessages(markup: string): Message[] {
 
       return messageObj;
     }),
-  ].filter(Boolean);
+  ].filter((Boolean as unknown) as (x: Message | null) => x is Message);
 }
 
 export function extractMessages(

--- a/src/cli/includes/getObjFromExpression.ts
+++ b/src/cli/includes/getObjFromExpression.ts
@@ -2,10 +2,8 @@ import type { ObjectExpression, Property, Identifier } from 'estree';
 
 import type { Message } from '../types';
 
-export function getObjFromExpression(
-  exprNode: ObjectExpression,
-): Partial<Message> {
-  return exprNode.properties.reduce<Partial<Message>>((acc, prop: Property) => {
+export function getObjFromExpression(exprNode: ObjectExpression): Message {
+  return exprNode.properties.reduce((acc, prop: Property) => {
     // we only want primitives
     if (
       prop.value.type === 'Literal' &&
@@ -17,5 +15,5 @@ export function getObjFromExpression(
     }
 
     return acc;
-  }, {});
+  }, {} as Message);
 }

--- a/src/cli/includes/getObjFromExpression.ts
+++ b/src/cli/includes/getObjFromExpression.ts
@@ -2,8 +2,10 @@ import type { ObjectExpression, Property, Identifier } from 'estree';
 
 import type { Message } from '../types';
 
-export function getObjFromExpression(exprNode: ObjectExpression) {
-  return exprNode.properties.reduce<Message>((acc, prop: Property) => {
+export function getObjFromExpression(
+  exprNode: ObjectExpression,
+): Partial<Message> {
+  return exprNode.properties.reduce<Partial<Message>>((acc, prop: Property) => {
     // we only want primitives
     if (
       prop.value.type === 'Literal' &&

--- a/src/cli/types/index.ts
+++ b/src/cli/types/index.ts
@@ -1,5 +1,5 @@
 export interface Message {
   id: string;
-  default: string;
+  default?: string;
   [key: string]: any;
 }

--- a/src/cli/types/index.ts
+++ b/src/cli/types/index.ts
@@ -1,5 +1,5 @@
 export interface Message {
-  id?: string;
-  default?: string;
+  id: string;
+  default: string;
   [key: string]: any;
 }

--- a/src/runtime/configs.ts
+++ b/src/runtime/configs.ts
@@ -38,7 +38,11 @@ export const defaultFormats: Formats = {
   },
 };
 
-export const defaultOptions: ConfigureOptions = {
+export const defaultOptions: Omit<
+  ConfigureOptions,
+  'fallbackLocale' | 'initialLocale'
+> &
+  Record<'fallbackLocale' | 'initialLocale', null> = {
   fallbackLocale: null,
   initialLocale: null,
   loadingDelay: 200,

--- a/src/runtime/configs.ts
+++ b/src/runtime/configs.ts
@@ -38,13 +38,8 @@ export const defaultFormats: Formats = {
   },
 };
 
-export const defaultOptions: Omit<
-  ConfigureOptions,
-  'fallbackLocale' | 'initialLocale'
-> &
-  Record<'fallbackLocale' | 'initialLocale', null> = {
-  fallbackLocale: null,
-  initialLocale: null,
+export const defaultOptions: ConfigureOptions = {
+  fallbackLocale: null as any,
   loadingDelay: 200,
   formats: defaultFormats,
   warnOnMissingMessages: true,

--- a/src/runtime/configs.ts
+++ b/src/runtime/configs.ts
@@ -1,4 +1,4 @@
-import type { ConfigureOptions } from './types';
+import type { ConfigureOptions, ConfigureOptionsInit } from './types';
 import { $locale } from './stores/locale';
 
 interface Formats {
@@ -47,13 +47,13 @@ export const defaultOptions: ConfigureOptions = {
   ignoreTag: true,
 };
 
-const options: ConfigureOptions = defaultOptions;
+const options: ConfigureOptions = defaultOptions as any;
 
 export function getOptions() {
   return options;
 }
 
-export function init(opts: ConfigureOptions) {
+export function init(opts: ConfigureOptionsInit) {
   const { formats, ...rest } = opts;
   const initialLocale = opts.initialLocale || opts.fallbackLocale;
 

--- a/src/runtime/includes/formatters.ts
+++ b/src/runtime/includes/formatters.ts
@@ -1,4 +1,3 @@
-import type { Formats } from 'intl-messageformat';
 import IntlMessageFormat from 'intl-messageformat';
 
 import type {
@@ -35,8 +34,8 @@ const getIntlFormatterOptions = (
 ): any => {
   const { formats } = getOptions();
 
-  if (type in formats && name in (formats as Formats)[type]) {
-    return (formats as Formats)[type][name];
+  if (type in formats && name in formats[type]) {
+    return formats[type][name];
   }
 
   throw new Error(`[svelte-i18n] Unknown "${name}" ${type} format.`);
@@ -106,6 +105,7 @@ export const getTimeFormatter: MemoizedDateTimeFormatterFactoryOptional = ({
 } = {}) => createTimeFormatter({ locale, ...args });
 
 export const getMessageFormatter = monadicMemoize(
+  // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
   (message: string, locale: string = getCurrentLocale()!) =>
     new IntlMessageFormat(message, locale, getOptions().formats, {
       ignoreTag: getOptions().ignoreTag,

--- a/src/runtime/includes/formatters.ts
+++ b/src/runtime/includes/formatters.ts
@@ -1,3 +1,4 @@
+import type { Formats } from 'intl-messageformat';
 import IntlMessageFormat from 'intl-messageformat';
 
 import type {
@@ -34,8 +35,8 @@ const getIntlFormatterOptions = (
 ): any => {
   const { formats } = getOptions();
 
-  if (type in formats && name in formats[type]) {
-    return formats[type][name];
+  if (type in formats && name in (formats as Formats)[type]) {
+    return (formats as Formats)[type][name];
   }
 
   throw new Error(`[svelte-i18n] Unknown "${name}" ${type} format.`);
@@ -105,7 +106,7 @@ export const getTimeFormatter: MemoizedDateTimeFormatterFactoryOptional = ({
 } = {}) => createTimeFormatter({ locale, ...args });
 
 export const getMessageFormatter = monadicMemoize(
-  (message: string, locale: string = getCurrentLocale()) =>
+  (message: string, locale: string = getCurrentLocale()!) =>
     new IntlMessageFormat(message, locale, getOptions().formats, {
       ignoreTag: getOptions().ignoreTag,
     }),

--- a/src/runtime/includes/formatters.ts
+++ b/src/runtime/includes/formatters.ts
@@ -1,6 +1,9 @@
 import IntlMessageFormat from 'intl-messageformat';
 
-import type { MemoizedIntlFormatter } from '../types';
+import type {
+  MemoizedIntlFormatter,
+  MemoizedIntlFormatterOptional,
+} from '../types';
 import { getCurrentLocale } from '../stores/locale';
 import { getOptions } from '../configs';
 import { monadicMemoize } from './memoize';
@@ -11,6 +14,16 @@ type MemoizedNumberFormatterFactory = MemoizedIntlFormatter<
 >;
 
 type MemoizedDateTimeFormatterFactory = MemoizedIntlFormatter<
+  Intl.DateTimeFormat,
+  Intl.DateTimeFormatOptions
+>;
+
+type MemoizedNumberFormatterFactoryOptional = MemoizedIntlFormatterOptional<
+  Intl.NumberFormat,
+  Intl.NumberFormatOptions
+>;
+
+type MemoizedDateTimeFormatterFactoryOptional = MemoizedIntlFormatterOptional<
   Intl.DateTimeFormat,
   Intl.DateTimeFormatOptions
 >;
@@ -76,17 +89,17 @@ const createTimeFormatter: MemoizedDateTimeFormatterFactory = monadicMemoize(
   },
 );
 
-export const getNumberFormatter: MemoizedNumberFormatterFactory = ({
+export const getNumberFormatter: MemoizedNumberFormatterFactoryOptional = ({
   locale = getCurrentLocale(),
   ...args
 } = {}) => createNumberFormatter({ locale, ...args });
 
-export const getDateFormatter: MemoizedDateTimeFormatterFactory = ({
+export const getDateFormatter: MemoizedDateTimeFormatterFactoryOptional = ({
   locale = getCurrentLocale(),
   ...args
 } = {}) => createDateFormatter({ locale, ...args });
 
-export const getTimeFormatter: MemoizedDateTimeFormatterFactory = ({
+export const getTimeFormatter: MemoizedDateTimeFormatterFactoryOptional = ({
   locale = getCurrentLocale(),
   ...args
 } = {}) => createTimeFormatter({ locale, ...args });

--- a/src/runtime/includes/loaderQueue.ts
+++ b/src/runtime/includes/loaderQueue.ts
@@ -62,7 +62,7 @@ function loadLocaleQueue(locale: string, localeQueue: MessagesLoader[]) {
 
 const activeFlushes: { [key: string]: Promise<void> } = {};
 
-export function flush(locale: string): Promise<void> {
+export async function flush(locale: string): Promise<void> {
   if (!hasLocaleQueue(locale)) {
     if (locale in activeFlushes) {
       return activeFlushes[locale];

--- a/src/runtime/includes/loaderQueue.ts
+++ b/src/runtime/includes/loaderQueue.ts
@@ -62,13 +62,13 @@ function loadLocaleQueue(locale: string, localeQueue: MessagesLoader[]) {
 
 const activeFlushes: { [key: string]: Promise<void> } = {};
 
-export async function flush(locale: string): Promise<void> {
+export function flush(locale: string): Promise<void> {
   if (!hasLocaleQueue(locale)) {
     if (locale in activeFlushes) {
       return activeFlushes[locale];
     }
 
-    return;
+    return Promise.resolve();
   }
 
   // get queue of XX-YY and XX locales

--- a/src/runtime/includes/loaderQueue.ts
+++ b/src/runtime/includes/loaderQueue.ts
@@ -41,7 +41,9 @@ function getLocalesQueues(locale: string) {
     .filter(([, localeQueue]) => localeQueue.length > 0);
 }
 
-export function hasLocaleQueue(locale: string) {
+export function hasLocaleQueue(locale?: string | null) {
+  if (locale == null) return false;
+
   return getPossibleLocales(locale).some(
     (localeQueue) => getLocaleQueue(localeQueue)?.size,
   );

--- a/src/runtime/includes/lookup.ts
+++ b/src/runtime/includes/lookup.ts
@@ -15,7 +15,7 @@ const addToCache = (path: string, locale: string, message: string) => {
   return message;
 };
 
-export const lookup = (path: string, refLocale: string) => {
+export const lookup = (path: string, refLocale: string | null | undefined) => {
   if (refLocale == null) return undefined;
 
   if (refLocale in lookupCache && path in lookupCache[refLocale]) {

--- a/src/runtime/index.ts
+++ b/src/runtime/index.ts
@@ -31,7 +31,7 @@ export function defineMessages(i: Record<string, MessageObject>) {
 }
 
 export function waitLocale(locale?: string) {
-  return flush(locale || getCurrentLocale() || getOptions().initialLocale);
+  return flush(locale || getCurrentLocale() || getOptions().initialLocale!);
 }
 
 export {

--- a/src/runtime/stores/dictionary.ts
+++ b/src/runtime/stores/dictionary.ts
@@ -34,7 +34,9 @@ export function getMessageFromDictionary(locale: string, id: string) {
   return match;
 }
 
-export function getClosestAvailableLocale(refLocale: string): string | null {
+export function getClosestAvailableLocale(
+  refLocale: string,
+): string | null | undefined {
   if (refLocale == null) return undefined;
 
   const relatedLocales = getPossibleLocales(refLocale);

--- a/src/runtime/stores/dictionary.ts
+++ b/src/runtime/stores/dictionary.ts
@@ -35,8 +35,8 @@ export function getMessageFromDictionary(locale: string, id: string) {
 }
 
 export function getClosestAvailableLocale(
-  refLocale: string,
-): string | null | undefined {
+  refLocale: string | null | undefined,
+): string | undefined {
   if (refLocale == null) return undefined;
 
   const relatedLocales = getPossibleLocales(refLocale);

--- a/src/runtime/stores/dictionary.ts
+++ b/src/runtime/stores/dictionary.ts
@@ -5,7 +5,6 @@ import type { LocaleDictionary, LocalesDictionary } from '../types/index';
 import { getPossibleLocales } from './locale';
 import { delve } from '../../shared/delve';
 import { lookupCache } from '../includes/lookup';
-import { locales } from '..';
 
 let dictionary: LocalesDictionary;
 const $dictionary = writable<LocalesDictionary>({});

--- a/src/runtime/stores/formatters.ts
+++ b/src/runtime/stores/formatters.ts
@@ -23,7 +23,7 @@ import { getCurrentLocale, getPossibleLocales, $locale } from './locale';
 const formatMessage: MessageFormatter = (id, options = {}) => {
   if (typeof id === 'object') {
     options = id as MessageObject;
-    id = options.id;
+    id = options.id!;
   }
 
   const {
@@ -90,11 +90,8 @@ const formatNumber: NumberFormatter = (n, options) => {
   return getNumberFormatter(options).format(n);
 };
 
-const getJSON: JSONGetter = <T = any>(
-  id: string,
-  locale = getCurrentLocale(),
-) => {
-  return lookup(id, locale) as T;
+const getJSON: JSONGetter = (id: string, locale = getCurrentLocale()): any => {
+  return lookup(id, locale);
 };
 
 export const $format = derived([$locale, $dictionary], () => formatMessage);

--- a/src/runtime/stores/formatters.ts
+++ b/src/runtime/stores/formatters.ts
@@ -47,7 +47,7 @@ const formatMessage: MessageFormatter = (id, options = {}) => {
         `[svelte-i18n] The message "${id}" was not found in "${getPossibleLocales(
           locale,
         ).join('", "')}".${
-          hasLocaleQueue(getCurrentLocale())
+          hasLocaleQueue(getCurrentLocale()!)
             ? `\n\nNote: there are at least one loader still registered to this locale that wasn't executed.`
             : ''
         }`,

--- a/src/runtime/stores/formatters.ts
+++ b/src/runtime/stores/formatters.ts
@@ -21,16 +21,18 @@ import { $dictionary } from './dictionary';
 import { getCurrentLocale, getPossibleLocales, $locale } from './locale';
 
 const formatMessage: MessageFormatter = (id, options = {}) => {
+  let messageObj = options as MessageObject;
+
   if (typeof id === 'object') {
-    options = id as MessageObject;
-    id = options.id!;
+    messageObj = id as MessageObject;
+    id = messageObj.id;
   }
 
   const {
     values,
     locale = getCurrentLocale(),
     default: defaultValue,
-  } = options;
+  } = messageObj;
 
   if (locale == null) {
     throw new Error(
@@ -47,7 +49,7 @@ const formatMessage: MessageFormatter = (id, options = {}) => {
         `[svelte-i18n] The message "${id}" was not found in "${getPossibleLocales(
           locale,
         ).join('", "')}".${
-          hasLocaleQueue(getCurrentLocale()!)
+          hasLocaleQueue(getCurrentLocale())
             ? `\n\nNote: there are at least one loader still registered to this locale that wasn't executed.`
             : ''
         }`,
@@ -90,8 +92,11 @@ const formatNumber: NumberFormatter = (n, options) => {
   return getNumberFormatter(options).format(n);
 };
 
-const getJSON: JSONGetter = (id: string, locale = getCurrentLocale()): any => {
-  return lookup(id, locale);
+const getJSON: JSONGetter = <T = any>(
+  id: string,
+  locale = getCurrentLocale(),
+) => {
+  return lookup(id, locale) as T;
 };
 
 export const $format = derived([$locale, $dictionary], () => formatMessage);

--- a/src/runtime/stores/locale.ts
+++ b/src/runtime/stores/locale.ts
@@ -29,11 +29,11 @@ export function getPossibleLocales(
 }
 
 export function getCurrentLocale() {
-  return current;
+  return current ?? undefined;
 }
 
 internalLocale.subscribe((newLocale: string | null | undefined) => {
-  current = newLocale;
+  current = newLocale ?? undefined;
 
   if (typeof window !== 'undefined' && newLocale != null) {
     document.documentElement.setAttribute('lang', newLocale);
@@ -42,9 +42,8 @@ internalLocale.subscribe((newLocale: string | null | undefined) => {
 
 const set = (newLocale: string | null | undefined): void | Promise<void> => {
   if (
-    ((getClosestAvailableLocale as unknown) as (
-      refLocale: string | null | undefined,
-    ) => refLocale is string)(newLocale) &&
+    newLocale &&
+    getClosestAvailableLocale(newLocale) &&
     hasLocaleQueue(newLocale)
   ) {
     const { loadingDelay } = getOptions();
@@ -66,7 +65,7 @@ const set = (newLocale: string | null | undefined): void | Promise<void> => {
       $isLoading.set(true);
     }
 
-    return flush(newLocale)
+    return flush(newLocale as string)
       .then(() => {
         internalLocale.set(newLocale);
       })

--- a/src/runtime/stores/locale.ts
+++ b/src/runtime/stores/locale.ts
@@ -6,7 +6,7 @@ import { getClosestAvailableLocale } from './dictionary';
 import { $isLoading } from './loading';
 
 let current: string;
-const $locale = writable(null);
+const $locale = writable<string | null | undefined>(null);
 
 function getSubLocales(refLocale: string) {
   return refLocale
@@ -77,7 +77,8 @@ $locale.set = (newLocale: string): void | Promise<void> => {
 };
 
 // istanbul ignore next
-$locale.update = (fn: (locale: string) => void | Promise<void>) =>
-  localeSet(fn(current));
+$locale.update = (
+  fn: (value: string | null | undefined) => string | null | undefined,
+) => localeSet(fn(current));
 
 export { $locale };

--- a/src/runtime/types/index.ts
+++ b/src/runtime/types/index.ts
@@ -26,8 +26,8 @@ export type InterpolationValues =
   | undefined;
 
 export interface MessageObject {
-  id?: string;
-  locale?: string | null;
+  id: string;
+  locale?: string;
   format?: string;
   default?: string;
   values?: InterpolationValues;
@@ -35,7 +35,7 @@ export interface MessageObject {
 
 export type MessageFormatter = (
   id: string | MessageObject,
-  options?: MessageObject,
+  options?: Omit<MessageObject, 'id'>,
 ) => string;
 
 export type TimeFormatter = (
@@ -53,11 +53,11 @@ export type NumberFormatter = (
   options?: IntlFormatterOptions<Intl.NumberFormatOptions>,
 ) => string;
 
-export type JSONGetter = (id: string, locale?: string | null) => any;
+export type JSONGetter = <T>(id: string, locale?: string | null) => T;
 
 type IntlFormatterOptions<T> = T & {
   format?: string;
-  locale?: string | null;
+  locale?: string;
 };
 
 export interface MemoizedIntlFormatter<T, U> {
@@ -74,8 +74,8 @@ export interface MessagesLoader {
 
 export interface ConfigureOptions {
   fallbackLocale: string;
-  formats: Partial<Formats>;
-  initialLocale: string;
+  initialLocale?: string | null;
+  formats: Formats;
   loadingDelay: number;
   warnOnMissingMessages: boolean;
   ignoreTag: boolean;

--- a/src/runtime/types/index.ts
+++ b/src/runtime/types/index.ts
@@ -1,4 +1,4 @@
-import type { FormatXMLElementFn, Formats } from 'intl-messageformat';
+import type { Formats, FormatXMLElementFn } from 'intl-messageformat';
 
 export interface LocaleDictionary {
   [key: string]:
@@ -27,7 +27,7 @@ export type InterpolationValues =
 
 export interface MessageObject {
   id?: string;
-  locale?: string;
+  locale?: string | null;
   format?: string;
   default?: string;
   values?: InterpolationValues;
@@ -53,11 +53,11 @@ export type NumberFormatter = (
   options?: IntlFormatterOptions<Intl.NumberFormatOptions>,
 ) => string;
 
-export type JSONGetter = (id: string, locale?: string) => any;
+export type JSONGetter = (id: string, locale?: string | null) => any;
 
 type IntlFormatterOptions<T> = T & {
   format?: string;
-  locale?: string;
+  locale?: string | null;
 };
 
 export interface MemoizedIntlFormatter<T, U> {
@@ -73,14 +73,13 @@ export interface MessagesLoader {
 }
 
 export interface ConfigureOptions {
-  fallbackLocale: string | null | undefined;
-  formats: Formats;
-  initialLocale: string | null;
+  fallbackLocale: string;
+  formats: Partial<Formats>;
+  initialLocale: string;
   loadingDelay: number;
   warnOnMissingMessages: boolean;
   ignoreTag: boolean;
 }
 
 export type ConfigureOptionsInit = Pick<ConfigureOptions, 'fallbackLocale'> &
-  Partial<Record<'formats', Partial<ConfigureOptions['formats']>>> &
-  Partial<Omit<ConfigureOptions, 'fallbackLocale' | 'formats'>>;
+  Partial<Omit<ConfigureOptions, 'fallbackLocale'>>;

--- a/src/runtime/types/index.ts
+++ b/src/runtime/types/index.ts
@@ -1,7 +1,11 @@
 import type { FormatXMLElementFn, Formats } from 'intl-messageformat';
 
 export interface LocaleDictionary {
-  [key: string]: LocaleDictionary | string | Array<string | LocaleDictionary>;
+  [key: string]:
+    | LocaleDictionary
+    | string
+    | Array<string | LocaleDictionary>
+    | null;
 }
 
 export type LocalesDictionary = {
@@ -49,7 +53,7 @@ export type NumberFormatter = (
   options?: IntlFormatterOptions<Intl.NumberFormatOptions>,
 ) => string;
 
-export type JSONGetter = <T>(id: string, locale?: string) => T;
+export type JSONGetter = (id: string, locale?: string) => any;
 
 type IntlFormatterOptions<T> = T & {
   format?: string;
@@ -57,6 +61,10 @@ type IntlFormatterOptions<T> = T & {
 };
 
 export interface MemoizedIntlFormatter<T, U> {
+  (options: IntlFormatterOptions<U>): T;
+}
+
+export interface MemoizedIntlFormatterOptional<T, U> {
   (options?: IntlFormatterOptions<U>): T;
 }
 
@@ -65,10 +73,14 @@ export interface MessagesLoader {
 }
 
 export interface ConfigureOptions {
-  fallbackLocale: string;
-  formats?: Partial<Formats>;
-  initialLocale?: string;
-  loadingDelay?: number;
-  warnOnMissingMessages?: boolean;
-  ignoreTag?: boolean;
+  fallbackLocale: string | null | undefined;
+  formats: Formats;
+  initialLocale: string | null;
+  loadingDelay: number;
+  warnOnMissingMessages: boolean;
+  ignoreTag: boolean;
 }
+
+export type ConfigureOptionsInit = Pick<ConfigureOptions, 'fallbackLocale'> &
+  Partial<Record<'formats', Partial<ConfigureOptions['formats']>>> &
+  Partial<Omit<ConfigureOptions, 'fallbackLocale' | 'formats'>>;

--- a/test/runtime/configs.test.ts
+++ b/test/runtime/configs.test.ts
@@ -10,7 +10,7 @@ import {
 import { $locale } from '../../src/runtime/stores/locale';
 
 beforeEach(() => {
-  init(defaultOptions);
+  init(defaultOptions as any);
 });
 
 test('inits the fallback locale', () => {

--- a/test/runtime/includes/formatters.test.ts
+++ b/test/runtime/includes/formatters.test.ts
@@ -10,7 +10,7 @@ import {
 const formatsJson = require('../../fixtures/formats.json');
 
 beforeEach(() => {
-  init({ fallbackLocale: undefined });
+  init({ fallbackLocale: undefined as any });
 });
 
 describe('number formatter', () => {

--- a/test/runtime/includes/loaderQueue.test.ts
+++ b/test/runtime/includes/loaderQueue.test.ts
@@ -23,8 +23,8 @@ test('checks if exist queues of locale and its fallbacks', () => {
   expect(hasLocaleQueue('en-US')).toBe(true);
 });
 
-test("does nothing if there's no queue for a locale", () => {
-  expect(flush('foo')).toBeUndefined();
+test("does nothing if there's no queue for a locale", async () => {
+  expect(await flush('foo')).toBeUndefined();
 });
 
 test('flushes the queue of a locale and its fallbacks and merge the result with the dictionary', async () => {

--- a/test/runtime/includes/utils.test.ts
+++ b/test/runtime/includes/utils.test.ts
@@ -8,7 +8,7 @@ import {
 
 describe('getting client locale', () => {
   beforeEach(() => {
-    delete window.location;
+    delete (window as any).location;
     window.location = {
       pathname: '/',
       hostname: 'example.com',

--- a/test/runtime/includes/utils.test.ts
+++ b/test/runtime/includes/utils.test.ts
@@ -8,13 +8,16 @@ import {
 
 describe('getting client locale', () => {
   beforeEach(() => {
-    delete (window as any).location;
+    // @ts-expect-error - TS doesn't know this is a fake window object
+    delete window.location;
+
+    // @ts-expect-error - TS doesn't know this is a fake window object
     window.location = {
       pathname: '/',
       hostname: 'example.com',
       hash: '',
       search: '',
-    } as any;
+    };
   });
 
   it('gets the locale based on the passed hash parameter', () => {

--- a/test/runtime/stores/locale.test.ts
+++ b/test/runtime/stores/locale.test.ts
@@ -11,7 +11,7 @@ import { register, isLoading } from '../../../src/runtime';
 import { hasLocaleQueue } from '../../../src/runtime/includes/loaderQueue';
 
 beforeEach(() => {
-  init({ fallbackLocale: undefined });
+  init({ fallbackLocale: undefined as any });
   $locale.set(undefined);
 });
 
@@ -90,7 +90,7 @@ test('if no initial locale is set, set the locale to the fallback', () => {
 test('if no initial locale was found, set to the fallback locale', () => {
   init({
     fallbackLocale: 'en',
-    initialLocale: null,
+    initialLocale: null as any,
   });
   expect(get($locale)).toBe('en');
   expect(getOptions().fallbackLocale).toBe('en');

--- a/test/runtime/stores/locale.test.ts
+++ b/test/runtime/stores/locale.test.ts
@@ -90,7 +90,6 @@ test('if no initial locale is set, set the locale to the fallback', () => {
 test('if no initial locale was found, set to the fallback locale', () => {
   init({
     fallbackLocale: 'en',
-    initialLocale: null as any,
   });
   expect(get($locale)).toBe('en');
   expect(getOptions().fallbackLocale).toBe('en');

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,10 +1,12 @@
 {
   "compilerOptions": {
     "allowJs": true,
+    "strictNullChecks": true,
     "noImplicitAny": true,
     "sourceMap": false,
     "module": "esnext",
     "moduleResolution": "node",
+    "skipLibCheck": true,
     "esModuleInterop": true,
     "resolveJsonModule": true,
     "target": "es2017",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1242,9 +1242,9 @@
   integrity sha512-lg55ArB+ZiHHbBBttLpzD07akz0QPrZgUODNakeC09i62dnrywr9mFErHuaPlB6I7z+sEbK+IYmplahvplCj2g==
 
 "@types/node@^14.14.35":
-  version "14.14.35"
-  resolved "https://registry.yarnpkg.com/@types/node/-/node-14.14.35.tgz#42c953a4e2b18ab931f72477e7012172f4ffa313"
-  integrity sha512-Lt+wj8NVPx0zUmUwumiVXapmaLUcAk3yPuHCFVXras9k5VT9TdhJqKqGVUQCD60OTMCl0qxJ57OiTL0Mic3Iag==
+  version "14.17.11"
+  resolved "https://registry.yarnpkg.com/@types/node/-/node-14.17.11.tgz#82d266d657aec5ff01ca59f2ffaff1bb43f7bf0f"
+  integrity sha512-n2OQ+0Bz6WEsUjrvcHD1xZ8K+Kgo4cn9/w94s1bJS690QMUWfJPW/m7CCb7gPkA1fcYwL2UpjXP/rq/Eo41m6w==
 
 "@types/normalize-package-data@^2.4.0":
   version "2.4.0"


### PR DESCRIPTION
### Before submitting the PR, please make sure you do the following

- [N/A] It's really useful if your PR relates to an outstanding issue, so please reference it in your PR, or create an explanatory one for discussion. In many cases features are absent for a reason.
- [N/A] This message body should clearly illustrate what problems it solves. If there are related issues, remember to reference them.
- [x] Ideally, include a test that fails without this PR but passes with it. PRs will only be merged once they pass CI. (Remember to `npm run lint`!)

### Tests

- [x] Run the tests tests with `npm test` or `yarn test`


### Context

This PR provides benefits not only for svelte-i18n dev but also for svelte-i18n users.

`strictNullCheck` is defaulted to `false` and it causes some unsafe typing. This PR introduces `strictNullChecks: true`.

This PR includes also fixes for type bugs (and this was original issue what I did want to fix).
For example, `$locale` is changed to `Writable<string | null | undefined>` instead of `Writable<string>`.
It is more exact typing from project that uses `strictNullChecks` because it can be `null` if the project uses `register(...)`.

Most of this PR does not break runtime behavior. Please note that `!` (non-null assertion) does not effect to runtime.

The only change for runtime is in `src/runtime/includes/loaderQueue.ts`.

```diff
-export function flush(locale: string): Promise<void> {
+export async function flush(locale: string): Promise<void> {
```

I thought this line is bug because it is used with `.then(...)` in https://github.com/kaisermann/svelte-i18n/blob/70725828bd3aa2ba77fe37dccb2890c57b27f6e4/src/runtime/stores/locale.ts#L67-L67
Yes, this discovery is benefit of `strictNullChecks`. (`(): Promise<void> => {return;}` is only valid in `strictNulChecks: false`)

Test is also only changed for this in runtime level.

---

```diff
-export type JSONGetter = <T>(id: string, locale?: string) => T;
+export type JSONGetter = (id: string, locale?: string) => any;
```

Function that only has type parameter not used in argument is essentially not generic function.

You can find the description in https://github.com/DefinitelyTyped/DefinitelyTyped#common-mistakes .

> a type parameter does not appear in the types of any parameters, you don't really have a generic function, you just have a disguised type assertion. Prefer to use a real type assertion, e.g. getMeAT() as number. 
