### PR TITLE
Allow to initialize a non-singleton i18n client.

### DIFF
--- a/src/runtime/client.ts
+++ b/src/runtime/client.ts
@@ -1,0 +1,132 @@
+import { setContext, getContext, hasContext, onDestroy } from 'svelte';
+import { Writable, Readable } from "svelte/store";
+
+import type {
+  MessageFormatter,
+  TimeFormatter,
+  DateFormatter,
+  NumberFormatter,
+  JSONGetter,
+  ConfigureOptionsInit,
+} from './types';
+
+import { applyOptions, getOptions } from './configs';
+
+import { $isLoading, createLoadingStore } from "./stores/loading";
+import { $locale, createLocaleStore } from "./stores/locale";
+import { $format, $formatDate, $formatNumber, $formatTime, $getJSON, createFormattingStores } from "./stores/formatters";
+
+export type I18nClient = {
+  locale: Writable<string | null | undefined>,
+  isLoading: Readable<boolean>,
+  format: Readable<MessageFormatter>,
+  t: Readable<MessageFormatter>,
+  _: Readable<MessageFormatter>,
+  time: Readable<TimeFormatter>,
+  date: Readable<DateFormatter>,
+  number: Readable<NumberFormatter>,
+  json: Readable<JSONGetter>,
+}
+
+export function createI18nClient(opts?: ConfigureOptionsInit): I18nClient {
+  const isLoading = createLoadingStore();
+
+  const options = { ...getOptions() };
+  const initialLocale = applyOptions(opts, options);
+
+  const { localeStore } = createLocaleStore(isLoading, options.loadingDelay);
+  localeStore.set(initialLocale);
+
+  const { format, formatTime, formatDate, formatNumber, getJSON } = createFormattingStores(
+    localeStore, () => options);
+
+  return {
+    locale: localeStore,
+    isLoading,
+    format,
+    t: format,
+    _: format,
+    time: formatTime,
+    date: formatDate,
+    number: formatNumber,
+    json: getJSON,
+  };
+}
+
+const globalClient: I18nClient = {
+  locale: $locale,
+  isLoading: $isLoading,
+  format: $format,
+  t: $format,
+  _: $format,
+  time: $formatTime,
+  date: $formatDate,
+  number: $formatNumber,
+  json: $getJSON,
+}
+
+const key = {};
+
+const lifecycleFuncsStyle = { hasContext, setContext, getContext, onDestroy };
+let lifecycleFuncs: typeof lifecycleFuncsStyle | null = null;
+
+// Need the user to init it once, since we can't get the relevant functions by ourself by the way svelte compiling works.
+// That is due to the fact that svelte is not a runtime dependency, rather just a code generator.
+// It means for example that the svelte function "hasContext" is different between what this library sees,
+//   and what the user uses.
+export function initLifecycleFuncs(funcs: typeof lifecycleFuncsStyle) {
+  lifecycleFuncs = { ...funcs };
+}
+
+function verifyLifecycleFuncsInit() {
+  if (!lifecycleFuncs) {
+    throw "Error: Lifecycle functions aren't initialized! Use initLifecycleFuncs() before.";
+  }
+}
+
+type ClientContainer = { client: I18nClient | null };
+
+// All the functions below can be called only in Svelte component initialization.
+
+export function setI18nClientInContext(i18nClient: I18nClient) : ClientContainer {
+  verifyLifecycleFuncsInit();
+
+  const clientContainer = { client: i18nClient };
+  lifecycleFuncs!.setContext(key, clientContainer);
+  return clientContainer;
+}
+
+export function clearI18nClientInContext(clientContainer: ClientContainer) {
+  clientContainer.client = null;
+}
+
+// A shortcut function that initializes i18n client in context on component initialization
+//    and cleans it on component destruction.
+export function setupI18nClientInComponentInit(opts?: ConfigureOptionsInit): I18nClient {
+  verifyLifecycleFuncsInit();
+
+  const client = createI18nClient(opts);
+  const container = setI18nClientInContext(client);
+
+  // We clean the client from the context for robustness.
+  //  Should svelte clean it by itself?
+  //  Anyway it seems safer, because of the ability of the user to give custom lifecycle funcs.
+  lifecycleFuncs!.onDestroy(() => clearI18nClientInContext(container));
+
+  return client;
+}
+
+export function getI18nClientInComponentInit():  I18nClient {
+  // Notice that unlike previous functions, calling this one without initializing lifecycle function is fine.
+  // In this case, the global client will be returned.
+
+  if (lifecycleFuncs?.hasContext(key)) {
+    const { client } = lifecycleFuncs!.getContext<ClientContainer>(key);
+    if (client !== null) {
+      return client;
+    }
+  }
+  // otherwise
+  
+  return globalClient;
+}

--- a/src/runtime/configs.ts
+++ b/src/runtime/configs.ts
@@ -68,13 +68,19 @@ export const defaultOptions: ConfigureOptions = {
   ignoreTag: true,
 };
 
-const options: ConfigureOptions = defaultOptions as any;
+// Deep copy to options
+const options: ConfigureOptions = JSON.parse(JSON.stringify(defaultOptions)) as any;
 
 export function getOptions() {
   return options;
 }
 
-export function init(opts: ConfigureOptionsInit) {
+export function applyOptions(opts: ConfigureOptionsInit | undefined, target: ConfigureOptions) {
+  if (opts === undefined) {
+    return undefined;
+  }
+  // otherwise
+
   const { formats, ...rest } = opts;
   // eslint-disable-next-line @typescript-eslint/prefer-nullish-coalescing
   const initialLocale = opts.initialLocale || opts.fallbackLocale;
@@ -91,21 +97,27 @@ export function init(opts: ConfigureOptionsInit) {
     }
   }
 
-  Object.assign(options, rest, { initialLocale });
+  Object.assign(target, rest, { initialLocale });
 
   if (formats) {
     if ('number' in formats) {
-      Object.assign(options.formats.number, formats.number);
+      Object.assign(target.formats.number, formats.number);
     }
 
     if ('date' in formats) {
-      Object.assign(options.formats.date, formats.date);
+      Object.assign(target.formats.date, formats.date);
     }
 
     if ('time' in formats) {
-      Object.assign(options.formats.time, formats.time);
+      Object.assign(target.formats.time, formats.time);
     }
   }
+
+  return initialLocale;
+}
+
+export function init(opts: ConfigureOptionsInit) {
+  const initialLocale = applyOptions(opts, getOptions());
 
   return $locale.set(initialLocale);
 }

--- a/src/runtime/index.ts
+++ b/src/runtime/index.ts
@@ -24,6 +24,8 @@ import {
   getTimeFormatter,
   getMessageFormatter,
 } from './includes/formatters';
+import { createI18nClient, initLifecycleFuncs, setI18nClientInContext, clearI18nClientInContext,
+  setupI18nClientInComponentInit, getI18nClientInComponentInit } from './client';
 
 // defineMessages allow us to define and extract dynamic message ids
 export function defineMessages(i: Record<string, MessageObject>) {
@@ -64,4 +66,11 @@ export {
   getLocaleFromNavigator,
   getLocaleFromQueryString,
   getLocaleFromHash,
+  // Client
+  createI18nClient,
+  initLifecycleFuncs,
+  setI18nClientInContext,
+  clearI18nClientInContext,
+  setupI18nClientInComponentInit,
+  getI18nClientInComponentInit,
 };

--- a/src/runtime/stores/loading.ts
+++ b/src/runtime/stores/loading.ts
@@ -1,3 +1,7 @@
-import { writable } from 'svelte/store';
+import { writable, Writable } from 'svelte/store';
 
-export const $isLoading = writable(false);
+export function createLoadingStore() : Writable<boolean> {
+  return writable(false);
+}
+
+export const $isLoading = createLoadingStore();

--- a/src/runtime/stores/locale.ts
+++ b/src/runtime/stores/locale.ts
@@ -1,12 +1,9 @@
-import { writable } from 'svelte/store';
+import { writable, Writable } from 'svelte/store';
 
 import { flush, hasLocaleQueue } from '../includes/loaderQueue';
 import { getOptions } from '../configs';
 import { getClosestAvailableLocale } from './dictionary';
 import { $isLoading } from './loading';
-
-let current: string | null | undefined;
-const internalLocale = writable<string | null | undefined>(null);
 
 function getSubLocales(refLocale: string) {
   return refLocale
@@ -28,59 +25,72 @@ export function getPossibleLocales(
   return locales;
 }
 
-export function getCurrentLocale() {
-  return current ?? undefined;
-}
+export function createLocaleStore(isLoading: Writable<boolean>, loadingDelayInit?: number) : {
+  localeStore: Writable<string | null | undefined>,
+  getCurrentLocale: () => string | undefined
+} {
+  let current : string | null | undefined;
+  const internalLocale = writable<string | null | undefined>(null);
 
-internalLocale.subscribe((newLocale: string | null | undefined) => {
-  current = newLocale ?? undefined;
-
-  if (typeof window !== 'undefined' && newLocale != null) {
-    document.documentElement.setAttribute('lang', newLocale);
+  function getCurrentLocale() {
+    return current ?? undefined;
   }
-});
 
-const set = (newLocale: string | null | undefined): void | Promise<void> => {
-  if (
-    newLocale &&
-    getClosestAvailableLocale(newLocale) &&
-    hasLocaleQueue(newLocale)
-  ) {
-    const { loadingDelay } = getOptions();
+  internalLocale.subscribe((newLocale: string | null | undefined) => {
+    current = newLocale ?? undefined;
 
-    let loadingTimer: number;
+    if (typeof window !== 'undefined' && newLocale != null) {
+      document.documentElement.setAttribute('lang', newLocale);
+    }
+  });
 
-    // if there's no current locale, we don't wait to set isLoading to true
-    // because it would break pages when loading the initial locale
+  const set = (newLocale: string | null | undefined): void | Promise<void> => {
     if (
-      typeof window !== 'undefined' &&
-      getCurrentLocale() != null &&
-      loadingDelay
+      newLocale &&
+      getClosestAvailableLocale(newLocale) &&
+      hasLocaleQueue(newLocale)
     ) {
-      loadingTimer = window.setTimeout(
-        () => $isLoading.set(true),
-        loadingDelay,
-      );
-    } else {
-      $isLoading.set(true);
+      const loadingDelay = loadingDelayInit ?? getOptions().loadingDelay;
+
+      let loadingTimer: number;
+
+      // if there's no current locale, we don't wait to set isLoading to true
+      // because it would break pages when loading the initial locale
+      if (
+        typeof window !== 'undefined' &&
+        getCurrentLocale() != null &&
+        loadingDelay
+      ) {
+        loadingTimer = window.setTimeout(
+          () => isLoading.set(true),
+          loadingDelay,
+        );
+      } else {
+        isLoading.set(true);
+      }
+
+      return flush(newLocale as string)
+        .then(() => {
+          internalLocale.set(newLocale);
+        })
+        .finally(() => {
+          clearTimeout(loadingTimer);
+          isLoading.set(false);
+        });
     }
 
-    return flush(newLocale as string)
-      .then(() => {
-        internalLocale.set(newLocale);
-      })
-      .finally(() => {
-        clearTimeout(loadingTimer);
-        $isLoading.set(false);
-      });
-  }
+    return internalLocale.set(newLocale);
+  };
 
-  return internalLocale.set(newLocale);
-};
+  const store = {
+    ...internalLocale,
+    set,
+  };
 
-const $locale = {
-  ...internalLocale,
-  set,
-};
+  return { localeStore: store, getCurrentLocale };
+}
 
-export { $locale };
+const { getCurrentLocale, localeStore } = createLocaleStore($isLoading);
+
+export { getCurrentLocale };
+export const $locale = localeStore;

--- a/src/runtime/types/index.ts
+++ b/src/runtime/types/index.ts
@@ -38,6 +38,13 @@ export type MessageFormatter = (
   options?: Omit<MessageObject, 'id'>,
 ) => string;
 
+export type MessageFormatterExtended = (
+  id: string | MessageObject,
+  options: Omit<MessageObject, 'id'>,
+  fallbackLocale: string | undefined,
+  _options: ConfigureOptions,
+) => string;
+
 export type TimeFormatter = (
   d: Date | number,
   options?: IntlFormatterOptions<Intl.DateTimeFormatOptions>,
@@ -53,10 +60,11 @@ export type NumberFormatter = (
   options?: IntlFormatterOptions<Intl.NumberFormatOptions>,
 ) => string;
 
-export type JSONGetter = <T>(id: string, locale?: string | null) => T;
+export type JSONGetter = <T>(id: string, locale?: string | undefined) => T;
 
 type IntlFormatterOptions<T> = T & {
   format?: string;
+  formats?: Formats;
   locale?: string;
 };
 

--- a/test/runtime/configs.test.ts
+++ b/test/runtime/configs.test.ts
@@ -1,13 +1,22 @@
 /* eslint-disable node/global-require */
 import { get } from 'svelte/store';
 
-import { init, getOptions, defaultFormats } from '../../src/runtime/configs';
+import { init, getOptions, defaultFormats, applyOptions } from '../../src/runtime/configs';
 import { $locale } from '../../src/runtime/stores/locale';
 
 const warnSpy = jest.spyOn(global.console, 'warn').mockImplementation();
 
 beforeEach(() => {
   warnSpy.mockReset();
+});
+
+test('check that empty source configuration do nothing', () => {
+  const originalOptions = { ...getOptions() };
+  const options = { ...originalOptions };
+  const locale = applyOptions(undefined, options);
+
+  expect(locale).toBe(undefined);
+  expect(options).toEqual(originalOptions);
 });
 
 test('inits the fallback locale', () => {

--- a/test/runtime/stores/formatters.test.ts
+++ b/test/runtime/stores/formatters.test.ts
@@ -7,6 +7,8 @@ import type {
   TimeFormatter,
   DateFormatter,
   NumberFormatter,
+  ConfigureOptions,
+  ConfigureOptionsInit,
 } from '../../../src/runtime/types';
 import {
   $format,
@@ -15,23 +17,17 @@ import {
   $formatNumber,
   $getJSON,
 } from '../../../src/runtime/stores/formatters';
-import { init } from '../../../src/runtime/configs';
+import { applyOptions, defaultOptions, getOptions, init } from '../../../src/runtime/configs';
 import { addMessages } from '../../../src/runtime/stores/dictionary';
 import { $locale } from '../../../src/runtime/stores/locale';
+import { createI18nClient, getI18nClientInComponentInit, I18nClient, initLifecycleFuncs,
+  setI18nClientInContext, setupI18nClientInComponentInit } from '../../../src/runtime/client';
 
 let formatMessage: MessageFormatter;
 let formatTime: TimeFormatter;
 let formatDate: DateFormatter;
 let formatNumber: NumberFormatter;
 let getJSON: JSONGetter;
-
-$locale.subscribe(() => {
-  formatMessage = get($format);
-  formatTime = get($formatTime);
-  formatDate = get($formatDate);
-  formatNumber = get($formatNumber);
-  getJSON = get($getJSON) as JSONGetter;
-});
 
 addMessages('en', require('../../fixtures/en.json'));
 addMessages('en-GB', require('../../fixtures/en-GB.json'));
@@ -40,141 +36,285 @@ addMessages('pt-BR', require('../../fixtures/pt-BR.json'));
 addMessages('pt-PT', require('../../fixtures/pt-PT.json'));
 
 describe('format message', () => {
-  it('formats a message by its id and the current locale', () => {
-    init({ fallbackLocale: 'en' });
+  function performTest(init: (opts: ConfigureOptionsInit) => void, setLocale: (locale: string | null) => void) {
+    it('formats a message by its id and the current locale', () => {
+      init({ fallbackLocale: 'en' });
 
-    expect(formatMessage({ id: 'form.field_1_name' })).toBe('Name');
-  });
-
-  it('formats a message by its id and the a passed locale', () => {
-    expect(formatMessage({ id: 'form.field_1_name', locale: 'pt' })).toBe(
-      'Nome',
-    );
-  });
-
-  it('formats a message with interpolated values', () => {
-    init({ fallbackLocale: 'en' });
-
-    expect(formatMessage({ id: 'photos', values: { n: 0 } })).toBe(
-      'You have no photos.',
-    );
-    expect(formatMessage({ id: 'photos', values: { n: 1 } })).toBe(
-      'You have one photo.',
-    );
-    expect(formatMessage({ id: 'photos', values: { n: 21 } })).toBe(
-      'You have 21 photos.',
-    );
-  });
-
-  it('formats the default value with interpolated values', () => {
-    init({ fallbackLocale: 'en' });
-
-    expect(
-      formatMessage({
-        id: 'non-existent',
-        default: '{food}',
-        values: { food: 'potato' },
-      }),
-    ).toBe('potato');
-  });
-
-  it('formats the key with interpolated values', () => {
-    init({ fallbackLocale: 'en' });
-
-    expect(
-      formatMessage({
-        id: '{food}',
-        values: { food: 'potato' },
-      }),
-    ).toBe('potato');
-  });
-
-  it('accepts a message id as first argument', () => {
-    init({ fallbackLocale: 'en' });
-
-    expect(formatMessage('form.field_1_name')).toBe('Name');
-  });
-
-  it('accepts a message id as first argument and formatting options as second', () => {
-    init({ fallbackLocale: 'en' });
-
-    expect(formatMessage('form.field_1_name', { locale: 'pt' })).toBe('Nome');
-  });
-
-  it('throws if no locale is set', () => {
-    init({ fallbackLocale: 'en' });
-
-    $locale.set(null);
-
-    expect(() => formatMessage('form.field_1_name')).toThrow(
-      '[svelte-i18n] Cannot format a message without first setting the initial locale.',
-    );
-  });
-
-  it('uses a missing message default value', () => {
-    init({ fallbackLocale: 'en' });
-
-    expect(formatMessage('missing', { default: 'Missing Default' })).toBe(
-      'Missing Default',
-    );
-  });
-
-  it('errors out when value found is not string', () => {
-    init({ fallbackLocale: 'en' });
-
-    const spy = jest.spyOn(global.console, 'warn').mockImplementation();
-
-    expect(typeof formatMessage('form')).toBe('object');
-    expect(spy).toBeCalledWith(
-      `[svelte-i18n] Message with id "form" must be of type "string", found: "object". Gettin its value through the "$format" method is deprecated; use the "json" method instead.`,
-    );
-
-    spy.mockRestore();
-  });
-
-  it('warn on missing messages if "warnOnMissingMessages" is true', () => {
-    init({
-      fallbackLocale: 'en',
-      warnOnMissingMessages: true,
+      expect(formatMessage({ id: 'form.field_1_name' })).toBe('Name');
     });
 
-    const spy = jest.spyOn(global.console, 'warn').mockImplementation();
-
-    formatMessage('missing');
-
-    expect(spy).toBeCalledWith(
-      `[svelte-i18n] The message "missing" was not found in "en".`,
-    );
-
-    spy.mockRestore();
-  });
-
-  it('uses result of handleMissingMessage handler', () => {
-    init({
-      fallbackLocale: 'en',
-      handleMissingMessage: () => 'from handler',
+    it('formats a message by its id and the a passed locale', () => {
+      expect(formatMessage({ id: 'form.field_1_name', locale: 'pt' })).toBe(
+        'Nome',
+      );
     });
 
-    expect(formatMessage('should-default')).toBe('from handler');
+    it('formats a message with interpolated values', () => {
+      init({ fallbackLocale: 'en' });
+
+      expect(formatMessage({ id: 'photos', values: { n: 0 } })).toBe(
+        'You have no photos.',
+      );
+      expect(formatMessage({ id: 'photos', values: { n: 1 } })).toBe(
+        'You have one photo.',
+      );
+      expect(formatMessage({ id: 'photos', values: { n: 21 } })).toBe(
+        'You have 21 photos.',
+      );
+    });
+
+    it('formats the default value with interpolated values', () => {
+      init({ fallbackLocale: 'en' });
+
+      expect(
+        formatMessage({
+          id: 'non-existent',
+          default: '{food}',
+          values: { food: 'potato' },
+        }),
+      ).toBe('potato');
+    });
+
+    it('formats the key with interpolated values', () => {
+      init({ fallbackLocale: 'en' });
+
+      expect(
+        formatMessage({
+          id: '{food}',
+          values: { food: 'potato' },
+        }),
+      ).toBe('potato');
+    });
+
+    it('accepts a message id as first argument', () => {
+      init({ fallbackLocale: 'en' });
+
+      expect(formatMessage('form.field_1_name')).toBe('Name');
+    });
+
+    it('accepts a message id as first argument and formatting options as second', () => {
+      init({ fallbackLocale: 'en' });
+
+      expect(formatMessage('form.field_1_name', { locale: 'pt' })).toBe('Nome');
+    });
+
+    it('throws if no locale is set', () => {
+      init({ fallbackLocale: 'en' });
+
+      setLocale(null);
+
+      expect(() => formatMessage('form.field_1_name')).toThrow(
+        '[svelte-i18n] Cannot format a message without first setting the initial locale.',
+      );
+    });
+
+    it('uses a missing message default value', () => {
+      init({ fallbackLocale: 'en' });
+
+      expect(formatMessage('missing', { default: 'Missing Default' })).toBe(
+        'Missing Default',
+      );
+    });
+
+    it('errors out when value found is not string', () => {
+      init({ fallbackLocale: 'en' });
+
+      const spy = jest.spyOn(global.console, 'warn').mockImplementation();
+
+      expect(typeof formatMessage('form')).toBe('object');
+      expect(spy).toBeCalledWith(
+        `[svelte-i18n] Message with id "form" must be of type "string", found: "object". Gettin its value through the "$format" method is deprecated; use the "json" method instead.`,
+      );
+
+      spy.mockRestore();
+    });
+
+    it('warn on missing messages if "warnOnMissingMessages" is true', () => {
+      init({
+        fallbackLocale: 'en',
+        warnOnMissingMessages: true,
+      });
+
+      const spy = jest.spyOn(global.console, 'warn').mockImplementation();
+
+      formatMessage('missing');
+
+      expect(spy).toBeCalledWith(
+        `[svelte-i18n] The message "missing" was not found in "en".`,
+      );
+
+      spy.mockRestore();
+    });
+
+    it('uses result of handleMissingMessage handler', () => {
+      init({
+        fallbackLocale: 'en',
+        handleMissingMessage: () => 'from handler',
+      });
+
+      expect(formatMessage('should-default')).toBe('from handler');
+    });
+
+    it('does not throw with invalid syntax', () => {
+      init({ fallbackLocale: 'en' });
+
+      setLocale('en');
+      const spy = jest.spyOn(global.console, 'warn').mockImplementation();
+
+      // eslint-disable-next-line line-comment-position
+      formatMessage('with-syntax-error', { values: { name: 'John' } });
+
+      expect(spy).toHaveBeenCalledWith(
+        expect.stringContaining(
+          `[svelte-i18n] Message "with-syntax-error" has syntax error:`,
+        ),
+        expect.anything(),
+      );
+
+      spy.mockRestore();
+    });
+  }
+
+  // Running the tests
+
+  describe('Test by the global singleton initialization', () => {
+    function cleanInit() {
+      const initialConf: ConfigureOptions = JSON.parse(JSON.stringify(defaultOptions));
+      delete initialConf.warnOnMissingMessages;
+      applyOptions(initialConf, getOptions());
+      getOptions().handleMissingMessage = undefined;
+    }
+    beforeEach(cleanInit);
+    afterAll(cleanInit);
+
+    function setLocale(locale: string | null, override: boolean = true) {
+      if (override) {
+        $locale.set(locale);
+      }
+
+      formatMessage = get($format);
+      formatTime = get($formatTime);
+      formatDate = get($formatDate);
+      formatNumber = get($formatNumber);
+      getJSON = get($getJSON) as JSONGetter;
+    }
+
+    performTest((opts) => { init(opts); setLocale(null, false) }, setLocale);
   });
 
-  it('does not throw with invalid syntax', () => {
-    init({ fallbackLocale: 'en' });
+  function generateSetLocaleFunc(getClient: () => I18nClient | null) {
+    //Initial global functions
 
-    $locale.set('en');
-    const spy = jest.spyOn(global.console, 'warn').mockImplementation();
+    formatMessage = get($format);
+    formatTime = get($formatTime);
+    formatDate = get($formatDate);
+    formatNumber = get($formatNumber);
+    getJSON = get($getJSON) as JSONGetter;
+    
+    function setLocale(locale: string | null, override: boolean = true) {
+      const client: I18nClient | null = getClient();
 
-    // eslint-disable-next-line line-comment-position
-    formatMessage('with-syntax-error', { values: { name: 'John' } });
+      if (override) {
+        (client === null ? $locale : client.locale).set(locale);
+      }
 
-    expect(spy).toHaveBeenCalledWith(
-      expect.stringContaining(
-        `[svelte-i18n] Message "with-syntax-error" has syntax error:`,
-      ),
-      expect.anything(),
-    );
+      formatMessage = get(client === null ? $format : client.format);
+      formatTime = get(client === null ? $formatTime : client.time);
+      formatDate = get(client === null ? $formatDate : client.date);
+      formatNumber = get(client === null ? $formatNumber : client.number);
+      getJSON = get(client === null ? $getJSON : client.json) as JSONGetter;
+    }
 
-    spy.mockRestore();
+    return setLocale;
+  }
+
+  describe('Test by initializing i18n clients', () => {
+    let client: I18nClient | null = null;
+    
+    const setLocale = generateSetLocaleFunc(() => client);
+
+    function init(opts: ConfigureOptionsInit) {
+      client = createI18nClient(opts);
+      setLocale(get(client.locale) ?? null, false);
+    }
+
+    performTest(init, setLocale);
+  });
+
+  describe('Test by initializing i18n by setuping "svelte" contexts', () => {
+    let client: I18nClient | null = null;
+    
+    const setLocale = generateSetLocaleFunc(() => client);
+
+    const globalClient = getI18nClientInComponentInit();
+
+    // Testing that lifecycle behaving correctly
+
+    const errorMessage = "Error: Lifecycle functions aren't initialized! Use initLifecycleFuncs() before.";
+    expect(setI18nClientInContext).toThrowError(errorMessage);
+    expect(setupI18nClientInComponentInit).toThrowError(errorMessage);
+
+    let active: boolean;
+    let initCalled: boolean;
+    let keyTrack: any;
+    let valueTrack: any;
+    let onDestroyDo: null | (() => void);
+    initLifecycleFuncs({
+      hasContext(key: any) {
+        return key === keyTrack;
+      },
+      setContext<T>(key: any, context: T) {
+        keyTrack = key;
+        valueTrack = context;
+        active = true;
+      },
+      getContext<T>(key: any) {
+        expect(active).toBe(true);
+        expect(key).toBe(keyTrack);
+        return valueTrack;
+      },
+      onDestroy(fn) {
+        expect(onDestroyDo).toBe(null);
+        onDestroyDo = fn;
+      }
+    });
+
+    expect(getI18nClientInComponentInit()).toBe(globalClient);
+
+    function init(opts: ConfigureOptionsInit) {
+      expect(active).toBe(false);
+      expect(initCalled).toBe(false);
+
+      client = setupI18nClientInComponentInit(opts);
+      expect(getI18nClientInComponentInit()).toBe(client);
+
+      setLocale(get(client.locale) ?? null, false);
+
+      expect(active).toBe(true);
+
+      initCalled = true;
+    }
+    
+    beforeEach(() => {
+      active = false;
+      initCalled = false;
+      keyTrack = undefined;
+      valueTrack = undefined;
+      onDestroyDo = null;
+    });
+
+    afterEach(() => {
+      if (initCalled) {
+        expect(active).toBe(true);
+
+        expect(onDestroyDo).toBeTruthy();
+        onDestroyDo!();
+      }
+
+      expect(getI18nClientInComponentInit()).toBe(globalClient);
+    });
+
+    performTest(init, setLocale);
   });
 });
 


### PR DESCRIPTION
### Intro
Solves #165.

It was a hard and tough work, but I have managed to do it finally.
I have carefully redesign the code to be able (internally) to create new formatters and locales given some options (not necessarily the global ones from `getOption()`!).
Using the above, I could finally implement the function `createI18nClient()`.

Additionally, as I mentioned in the issue, the user may&should use the context based API (calling `setupI18nClientInComponentInit()`), so any component designer could get the i18n stores via `getI18nClientInComponentInit()`, see the next example.

### Seketch for the user


### Tests

Because of lint problems on base commits I just ignored it.
But Jest tests works very well, and I enhance them for checking the newly added code of mine.

I was also testing this in my own private svelte website project.
