### PR TITLE
Add support for svelte v4

### DIFF
--- a/package.json
+++ b/package.json
@@ -55,7 +55,7 @@
     ]
   },
   "peerDependencies": {
-    "svelte": "^3.25.1"
+    "svelte": "^3.25.1 || ^4.0.0"
   },
   "devDependencies": {
     "@babel/core": "^7.20.2",


### PR DESCRIPTION
Add svelte: `4.0.0` as a peer dependency so that this package can be used in svelte v4.

[Svelte v4 migration guide](https://svelte.dev/docs/v4-migration-guide#minimum-version-requirements)