### PR TITLE
cli extract lib check

### DIFF
--- a/docs/CLI.md
+++ b/docs/CLI.md
@@ -11,3 +11,5 @@ $ svelte-i18n extract [options] <glob-pattern> [output-file]
 - `--overwrite` - overwrite the content of the `output` file instead of just appending missing properties. Default: `false`.
 
 - `-c, --config` - define the path of a `svelte.config.js` in case your svelte components need to be preprocessed.
+
+- `--unsave` - disable the import library check. This can be used if the library name for some reason is not exactly "svelte-i18n". Default: `false`.

--- a/src/cli/index.ts
+++ b/src/cli/index.ts
@@ -51,11 +51,13 @@ program
     'path to the "svelte.config.js" file',
     `${process.cwd()}/svelte.config.js`,
   )
-  .action(async (globStr, output, { shallow, overwrite, config }) => {
+  .option('--unsave', 'disable the import-lib validation', false)
+  .action(async (globStr, output, { shallow, overwrite, config, unsave }) => {
     const filesToExtract = (await glob(globStr)).filter((file) =>
       file.match(/\.html|svelte$/i),
     );
 
+    const ignoreImport = unsave;
     const isConfigDir = await isDirectory(config);
     const resolvedConfigPath = resolve(
       config,
@@ -98,7 +100,7 @@ program
           content = processed.code;
         }
 
-        extractMessages(content, { accumulator, shallow });
+        extractMessages(content, { accumulator, shallow, ignoreImport });
       } catch (e: unknown) {
         if (
           isSvelteError(e, 'parse-error') &&

--- a/test/cli/extract.test.ts
+++ b/test/cli/extract.test.ts
@@ -26,6 +26,30 @@ describe('collecting format calls', () => {
     expect(calls).toHaveLength(0);
   });
 
+  it('returns nothing if import from wrong lib', () => {
+    const ast = parse(`<script>
+      import { _ } from '../helpers/i18n'
+      let label = $_('bar')
+    </script>`);
+
+    const calls = collectFormatCalls(ast);
+
+    expect(calls).toHaveLength(0);
+  });
+
+  it('returns all format calls if import from wrong lib and import-check is disabled', () => {
+    const ast = parse(`<script>
+      import { _ } from '../helpers/i18n'
+      let label = $_('bar')
+    </script>`);
+
+    const ignoreLib = true;
+    const calls = collectFormatCalls(ast, ignoreLib);
+
+    expect(calls).toHaveLength(1);
+    expect(calls[0]).toMatchObject({ type: 'CallExpression' });
+  });
+
   it('returns nothing if there are no format imports', () => {
     const ast = parse(
       `<script>


### PR DESCRIPTION
This solves #233 by introducing a new cli parameter `unsave` to disable lib-check in the extractor. see #233 for details.
