### PR TITLE
Bump svelte to support svelte 5

### DIFF
--- a/package.json
+++ b/package.json
@@ -55,7 +55,7 @@
     ]
   },
   "peerDependencies": {
-    "svelte": "^3 || ^4"
+    "svelte": "^3 || ^4 || ^5"
   },
   "devDependencies": {
     "@kiwi/eslint-config": "^2.2.8",


### PR DESCRIPTION
Update package.json to Support Svelte 5

This PR updates the package.json to support Svelte 5. The Svelte library is backwards compatible, ensuring that existing projects will continue to function without issues.

https://github.com/kaisermann/svelte-i18n/issues/248
